### PR TITLE
[Automated] Standardize Ballerina.toml keywords

### DIFF
--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -5,7 +5,7 @@ name = "spotify"
 version = "@toml.version@"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
-keywords = ["Vendor/Spotify", "Area/File Management", "Type/Connector"]
+keywords = ["Vendor/Spotify", "Area/Media", "Type/Connector"]
 # icon = "icon.png" # TODO: Add icon
 repository = "https://github.com/ballerina-platform/module-ballerinax-spotify"
 

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -5,7 +5,7 @@ name = "spotify"
 version = "@toml.version@"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
-keywords = [] # TODO: Add keywords
+keywords = ["# TODO: Add keywords", "Vendor/Spotify", "Area/File Management", "Type/Connector"]
 # icon = "icon.png" # TODO: Add icon
 repository = "https://github.com/ballerina-platform/module-ballerinax-spotify"
 

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -6,7 +6,7 @@ version = "@toml.version@"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Vendor/Spotify", "Area/Media", "Type/Connector"]
-# icon = "icon.png" # TODO: Add icon
+icon = "icon.png"
 repository = "https://github.com/ballerina-platform/module-ballerinax-spotify"
 
 [build-options]

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -5,7 +5,7 @@ name = "spotify"
 version = "@toml.version@"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
-keywords = ["# TODO: Add keywords", "Vendor/Spotify", "Area/File Management", "Type/Connector"]
+keywords = ["Vendor/Spotify", "Area/File Management", "Type/Connector"]
 # icon = "icon.png" # TODO: Add icon
 repository = "https://github.com/ballerina-platform/module-ballerinax-spotify"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR standardizes package metadata for the Ballerina Spotify connector by updating build-config/resources/Ballerina.toml to include descriptive keywords. The [package] section now lists ["Vendor/Spotify", "Area/Media", "Type/Connector"] (replacing a prior empty keywords list), improving the module's discoverability and classification within the Ballerina ecosystem.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->